### PR TITLE
Display Project Tags on Discover Page

### DIFF
--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -8,7 +8,24 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RoutingModule } from './routing/routing.module';
 import { ExampleComponent } from './example/example.component';
 import { LoginComponent } from './login/login.component';
-import { MatSnackBarModule, MatGridListModule, MatCardModule, MatMenuModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatSelectModule, MatRadioModule, MatToolbarModule, MatSidenavModule, MatIconModule, MatListModule, MatExpansionModule, MatChipsModule, MatAutocompleteModule} from '@angular/material';
+import {
+  MatAutocompleteModule,
+  MatButtonModule,
+  MatCardModule,
+  MatChipsModule,
+  MatExpansionModule,
+  MatFormFieldModule,
+  MatGridListModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule,
+  MatMenuModule,
+  MatRadioModule,
+  MatSelectModule,
+  MatSidenavModule,
+  MatSnackBarModule,
+  MatToolbarModule,
+} from '@angular/material';
 import { RegistrationComponent } from './registration/registration.component';
 import { HttpClientModule } from '@angular/common/http';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -22,6 +39,7 @@ import { ProfileComponent } from "./profile/profile.component";
 import { LogoutComponent } from './logout/logout.component';
 import { ProjectComponent } from './project/project.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
+import { TagsComponent } from './tags/tags.component';
 
 @NgModule({
   declarations: [
@@ -36,7 +54,8 @@ import { ProjectCardComponent } from './project-card/project-card.component';
     ProjectFormComponent,
     LogoutComponent,
     ProjectComponent,
-    ProjectCardComponent
+    ProjectCardComponent,
+    TagsComponent,
   ],
   imports: [
     BrowserAnimationsModule,

--- a/angular/src/app/discover/discover.component.html
+++ b/angular/src/app/discover/discover.component.html
@@ -1,6 +1,6 @@
 <app-search (searchEventEmitter)="onSearch($event)"></app-search>
 <div class="grid-container">
-  <mat-grid-list cols="4" rowHeight="410px">
+  <mat-grid-list cols="4" rowHeight="510px">
     <mat-grid-tile *ngFor="let project of projects" [colspan]="1" [rowspan]="1">
       <app-project-card [project]=project></app-project-card>
     </mat-grid-tile>

--- a/angular/src/app/discover/discover.component.ts
+++ b/angular/src/app/discover/discover.component.ts
@@ -22,7 +22,7 @@ export class DiscoverComponent implements OnInit {
   }
 
   getProjects() {
-    this.discoverService.getProjects().subscribe(
+    this.discoverService.getProjectsWithTags().subscribe(
       (response: Array<any>) => {
         this.projects = response;
       },

--- a/angular/src/app/discover/discover.service.spec.ts
+++ b/angular/src/app/discover/discover.service.spec.ts
@@ -17,4 +17,9 @@ describe('DiscoverService', () => {
     const service: DiscoverService = TestBed.get(DiscoverService);
     expect(service.getProjects).toBeDefined();
   });
+
+  it('should have a getProjectsWithTags function', () => {
+    const service: DiscoverService = TestBed.get(DiscoverService);
+    expect(service.getProjectsWithTags).toBeDefined();
+  });
 });

--- a/angular/src/app/discover/discover.service.ts
+++ b/angular/src/app/discover/discover.service.ts
@@ -9,7 +9,11 @@ export class DiscoverService {
   constructor(private httpClient: HttpService) { }
 
   getProjects() {
-      return this.httpClient.get(`api/projects`)
+    return this.httpClient.get(`api/projects`);
+  }
+
+  getProjectsWithTags() {
+    return this.httpClient.get(`api/projects?withTags=True`);
   }
 
   getProjectsBySearch(projects: string[]) {

--- a/angular/src/app/project-card/project-card.component.css
+++ b/angular/src/app/project-card/project-card.component.css
@@ -24,3 +24,26 @@
 	overflow: auto; 
   /* outline: 1px solid red; */
 }
+
+.profile-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  margin: 10px;
+}
+
+.profile-card-tags {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.profile-card-github {
+  width: 50%;
+  float: left;
+}
+
+.profile-card-user {
+  width: max-content;
+  float: right;
+}

--- a/angular/src/app/project-card/project-card.component.html
+++ b/angular/src/app/project-card/project-card.component.html
@@ -12,6 +12,7 @@
 
   <mat-card-footer>
     <div style="margin:15px">
+      <app-tags projectId="{{ project.id }}"></app-tags>
       <span style="float: left">
         <a href="{{ project.github }}" style="text-decoration: none">Project Link</a>
       </span>

--- a/angular/src/app/project-card/project-card.component.html
+++ b/angular/src/app/project-card/project-card.component.html
@@ -11,7 +11,7 @@
   </mat-card-content>
 
   <mat-card-footer class="profile-card-footer">
-    <app-tags class="profile-card-tags" projectId="{{ project.id }}"></app-tags>
+    <app-tags class="profile-card-tags" [tags]="project.tags"></app-tags>
     <span class="profile-card-github">
       <a href="{{ project.github }}" style="text-decoration: none">Project Link</a>
     </span>

--- a/angular/src/app/project-card/project-card.component.html
+++ b/angular/src/app/project-card/project-card.component.html
@@ -1,6 +1,6 @@
 <mat-card *ngIf="project" class="dashboard-card">
   <img (click)="redirectProject(project)" mat-card-image src="{{ project.image }}"
-    style="height: 250px; object-fit: cover;" />
+    style="height: 200px; object-fit: cover;" />
 
   <mat-card-title (click)="redirectProject(project)">
     {{ project.name }}
@@ -10,24 +10,16 @@
     <div>{{ project.description }}</div>
   </mat-card-content>
 
-  <mat-card-footer>
-    <div style="margin:15px">
-      <app-tags projectId="{{ project.id }}"></app-tags>
-      <span style="float: left">
-        <a href="{{ project.github }}" style="text-decoration: none">Project Link</a>
-      </span>
-
-      <span style="float: right">
-        <mat-card-actions>
-          <button id='discover-project' mat-raised-button color="primary" (click)="onEdit(project)"
-            *ngIf="project.owner.username == username" type="button">Edit</button>
-          <span style="float: right" *ngIf="project.owner.username != username">
-            {{ project.owner.username }}
-          </span>
-        </mat-card-actions>
-      </span>
-
-    </div>
+  <mat-card-footer class="profile-card-footer">
+    <app-tags class="profile-card-tags" projectId="{{ project.id }}"></app-tags>
+    <span class="profile-card-github">
+      <a href="{{ project.github }}" style="text-decoration: none">Project Link</a>
+    </span>
+    <button class="profile-card-user" id='discover-project' mat-raised-button color="primary" (click)="onEdit(project)"
+      *ngIf="project.owner.username == username" type="button">Edit</button>
+    <span class="profile-card-user" *ngIf="project.owner.username != username">
+      {{ project.owner.username }}
+    </span>
   </mat-card-footer>
 
 </mat-card>

--- a/angular/src/app/project-card/project-card.component.spec.ts
+++ b/angular/src/app/project-card/project-card.component.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectCardComponent } from './project-card.component';
-import { MatCardModule, MatButtonModule, MatIconModule } from '@angular/material';
+import { MatCardModule, MatChipsModule, MatButtonModule, MatIconModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TagsComponent } from '../tags/tags.component';
 
 describe('ProjectCardComponent', () => {
   let component: ProjectCardComponent;
@@ -10,10 +11,11 @@ describe('ProjectCardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ProjectCardComponent],
+      declarations: [ProjectCardComponent, TagsComponent],
       imports: [
         MatCardModule,
         MatButtonModule,
+        MatChipsModule,
         MatIconModule,
         RouterTestingModule
       ]

--- a/angular/src/app/search/search.service.ts
+++ b/angular/src/app/search/search.service.ts
@@ -6,7 +6,7 @@ import { Project } from '../models/project';
 import { User } from '../models/user';
 
 const GET_USERS_URL = 'api/users';
-const GET_PROJECTS_URL = 'api/projects';
+const GET_PROJECTS_URL = 'api/projects?withTags=True';
 
 @Injectable({providedIn: 'root'})
 export class SearchService {

--- a/angular/src/app/tags/tags.component.css
+++ b/angular/src/app/tags/tags.component.css
@@ -1,0 +1,5 @@
+mat-chip {
+  max-width: 200px;
+  font-size: 12px;
+  padding: 6px 6px;
+}

--- a/angular/src/app/tags/tags.component.html
+++ b/angular/src/app/tags/tags.component.html
@@ -1,5 +1,5 @@
-<mat-chip-list *ngIf="projectId">
-  <mat-chip *ngFor="let tag of tags" color="{{ tag.colour }}" selected>
-    {{tag.tag}}
+<mat-chip-list *ngIf="tags">
+  <mat-chip *ngFor="let tag of tags" color="{{ colour }}" selected>
+    {{tag}}
   </mat-chip>
 </mat-chip-list>

--- a/angular/src/app/tags/tags.component.html
+++ b/angular/src/app/tags/tags.component.html
@@ -1,0 +1,5 @@
+<mat-chip-list *ngIf="projectId">
+  <mat-chip *ngFor="let tag of tags" color="{{ tag.colour }}" selected>
+    {{tag.tag}}
+  </mat-chip>
+</mat-chip-list>

--- a/angular/src/app/tags/tags.component.spec.ts
+++ b/angular/src/app/tags/tags.component.spec.ts
@@ -1,0 +1,48 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TagsComponent } from './tags.component';
+import { MatChipsModule } from '@angular/material';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
+
+describe('TagsComponent', () => {
+  let component: TagsComponent;
+  let fixture: ComponentFixture<TagsComponent>;
+  const dummyTags = [{ tag: 'test', colour: 'primary' }];
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TagsComponent],
+      imports: [
+        MatChipsModule,
+        HttpClientTestingModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TagsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain a mat-chip element', () => {
+    expect(document.getElementsByTagName('mat-chip')).toBeTruthy();
+  });
+
+  it('should contain a tag', () => {
+    component.tags = dummyTags;
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      const chip = fixture.debugElement.query(By.css('.mat-chip'));
+      expect(chip.nativeElement.value).toEqual(dummyTags[0].tag);
+    });
+  });
+
+});

--- a/angular/src/app/tags/tags.component.spec.ts
+++ b/angular/src/app/tags/tags.component.spec.ts
@@ -8,7 +8,7 @@ import { By } from '@angular/platform-browser';
 describe('TagsComponent', () => {
   let component: TagsComponent;
   let fixture: ComponentFixture<TagsComponent>;
-  const dummyTags = [{ tag: 'test', colour: 'primary' }];
+  const dummyTags = ['test'];
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -41,7 +41,8 @@ describe('TagsComponent', () => {
 
     fixture.whenStable().then(() => {
       const chip = fixture.debugElement.query(By.css('.mat-chip'));
-      expect(chip.nativeElement.value).toEqual(dummyTags[0].tag);
+      console.log(chip.nativeElement)
+      expect(chip.nativeElement.innerText).toEqual(dummyTags[0]);
     });
   });
 

--- a/angular/src/app/tags/tags.component.ts
+++ b/angular/src/app/tags/tags.component.ts
@@ -7,26 +7,11 @@ import { TagsService } from './tags.service';
   styleUrls: ['./tags.component.css']
 })
 export class TagsComponent implements OnInit {
-  @Input() projectId = null;
+  @Input() tags: Array<String> = [];
   error: boolean = false;
-  tags: Array<any> = [];
   colour: 'primary';
-
 
   constructor(private tagsService: TagsService) { }
 
-  ngOnInit() {
-    this.getTags();
-  }
-
-  getTags() {
-    this.tagsService.getForProject(this.projectId).subscribe(
-      (response: Array<any>) => {
-        this.tags = response.map(tag => ({ tag: tag.tag, colour: this.colour }));
-      },
-      error => {
-        this.error = true;
-      }
-    );
-  }
+  ngOnInit() { }
 }

--- a/angular/src/app/tags/tags.component.ts
+++ b/angular/src/app/tags/tags.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { TagsService } from './tags.service';
+
+@Component({
+  selector: 'app-tags',
+  templateUrl: './tags.component.html',
+  styleUrls: ['./tags.component.css']
+})
+export class TagsComponent implements OnInit {
+  @Input() projectId = null;
+  error: boolean = false;
+  tags: Array<any> = [];
+  colour: 'primary';
+
+
+  constructor(private tagsService: TagsService) { }
+
+  ngOnInit() {
+    this.getTags();
+  }
+
+  getTags() {
+    this.tagsService.getForProject(this.projectId).subscribe(
+      (response: Array<any>) => {
+        this.tags = response.map(tag => ({ tag: tag.tag, colour: this.colour }));
+      },
+      error => {
+        this.error = true;
+      }
+    );
+  }
+}

--- a/angular/src/app/tags/tags.service.spec.ts
+++ b/angular/src/app/tags/tags.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TagsService } from './tags.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('TagsService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule]
+  }));
+
+  it('should be created', () => {
+    const service: TagsService = TestBed.get(TagsService);
+    expect(service).toBeTruthy();
+  });
+
+  it('should have a getForProject function', () => {
+    const service: TagsService = TestBed.get(TagsService);
+    expect(service.getForProject).toBeDefined();
+  });
+});

--- a/angular/src/app/tags/tags.service.ts
+++ b/angular/src/app/tags/tags.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpService } from '../http.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TagsService {
+
+  constructor(private httpClient: HttpService) { }
+
+  getForProject(projectId) {
+    return this.httpClient.get('api/tags/project/' + projectId);
+  }
+
+}


### PR DESCRIPTION
There are a few things that I think could be improved upon in this MR, but I'm not sure if they should be logged as issues for future improvements or fixed now.

I wasn't sure where to put the tags, so I put them in the footer of the Project Cards. Things look pretty squished. Maybe this is something that could be addressed in the design meeting?

<img width="331" alt="Screen Shot 2019-03-17 at 8 41 57 PM" src="https://user-images.githubusercontent.com/10265877/54500747-6b3faa80-48f6-11e9-9eb1-29832da46c18.png">

Also, I think there's an oppertunity to improve efficiency by adding a `with_tags` param to the `GET projects` API call. Right now, we make one API call per project to get the tags. We could instead just get the projects with their tags in one API call and map them out into the Tags component. Just a thought.
