### PR TITLE
Fixed github link issue

### DIFF
--- a/angular/src/app/project/project.component.html
+++ b/angular/src/app/project/project.component.html
@@ -34,13 +34,13 @@
                                     <a href="mailto:{{ user.email }}">{{ user.email }}</a>
                                 </div>
                             </mat-list-item>
-                            <mat-list-item *ngIf="project.github">
-                                <a href="https://github.com/{{ project.github }}">
+                            <mat-list-item *ngIf="github">
+                                <a href="https://github.com/{{ github }}">
                                     <fa-icon class="project-icon" [icon]="faGithub"></fa-icon>
                                 </a>
                                 <div class="single-link-container">
                                     <mat-label class="link-description">Github</mat-label>
-                                    <a href="https://github.com/{{ project.github }}">{{ project.github }}</a>
+                                    <a href="https://github.com/{{ github }}">{{ github }}</a>
                                 </div>
                             </mat-list-item>
                             <mat-list-item *ngIf="project.url">

--- a/angular/src/app/project/project.component.ts
+++ b/angular/src/app/project/project.component.ts
@@ -13,7 +13,7 @@ import { UserProfileService } from '../user-profile/user-profile.service';
 export class ProjectComponent implements OnInit {
     projectId: string;
     username: string;
-
+    github: string;
     project: any;
     user: any;
     associated_users: any;
@@ -40,6 +40,9 @@ export class ProjectComponent implements OnInit {
 
         this.projectService.getProject(this.projectId).subscribe((response) => {
             this.project = response;
+            if (this.project.github) {
+              this.github = this.project.github.replace("https://github.com/", "");
+            }
 
             this.userService.getUser(this.project.owner.username).subscribe((response) => {
                 this.user = response;


### PR DESCRIPTION
fixes #119

Our github links are not stored consistently, this is a temporary fix but eventually we should decide on a proper way to store and create some validation for whichever way we decide to store 

(The advantage of being able to store a link is that a user could pick exactly what they want to show for a project, for example one file that they are wanting help with)